### PR TITLE
Add support to Authorization with Basic Auth & Bearer Token, in…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ tokio = { version = "1.44.1", features = ["full"] }
 warp = "0.3.7"
 anyhow = "1.0.97"
 bytes = "1.10.1"
+base64 = "0.21.7"
+serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ cargo build --release
 /api/user:
   method: GET
   file: user_response.json
+  authentication:
+    basic:
+      user: 'admin'
+      password: 'secret'
 
 /api/order:
   method: POST
   file: order_data.json
-  status_code: 202 #custom Http Status code
+  status_code: 202 #custom Http status code
+  authentication:
+    bearer:
+      token: 'valid_token'
+      claims:
+        role: 'admin'
 ```
 This means:
 - `GET /api/user` &rarr; Returns `response/user_reponse.json`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Many developers need quick and flexible mock servers to simulate backend APIs du
 - 💾 **File-Based Storage**: Store and retrieve JSON responses without a database.
 - 🔄 **Dynamic API Handling**: Automatically updates responses with `POST`/`PUT`.
 - 🛠 **Unit-Tested**: Includes tests for configuration loading and request handling.
+- 🔐 **Authorization**: Supports mocking of **Basic Authentication** and **Bearer Token Authentication**:
+    - **Basic Auth**: Validates username and password based on the configuration.
+    - **Bearer Token**: Validates tokens and their claims, ensuring that the token matches expected values and claims (e.g., roles, permissions).
 
 ## Installation
 ### Prerequisites

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,10 @@
   method:
    - GET
   file: user_response.json
+  authentication:
+    basic:
+      user: USER_NAME
+      password: PASSWORD
 
 /api/order:
   method:
@@ -9,3 +13,10 @@
    - DELETE
   file: order_data.json
   status_code: 202 #custom Http Status code
+  authentication:
+    bearer:
+      token: TOKEN_STR
+      claims:
+        sub: SUB
+        name: NAME
+        iat: 1516238972

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,13 @@
 use serde::Deserialize;
 use std::{collections::HashMap, fs};
+use serde_yaml::Value;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Endpoint {
     pub method: Vec<String>,
     pub file: String,
     pub status_code: Option<u16>,
+    pub authentication: Option<Value>,
 }
 
 pub type Config = HashMap<String, Endpoint>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
+extern crate core;
+
 mod config;
 mod handler;
 mod server;
+mod authentication;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
**Feature:** Authorization Mocking with Basic Auth & Bearer Token, including Claim Validation

This pull request introduces a new feature to the mock server that enables mocking of both **Basic Authentication** and **Bearer Token Authentication**, along with **token claims validation**.

### **Key Changes:**

1. **Basic Authentication:**
   - Allows the server to mock Basic Authentication by validating the provided username and password in the `Authorization` header against the configuration defined in the `config.yaml` file.
   - If the username and password do not match, the server responds with an `Unauthorized` (401) status.

2. **Bearer Token Authentication:**
   - The server can now validate Bearer tokens provided in the `Authorization` header.
   - The token is validated against the predefined token value in the configuration.
   - **Claims Validation**: The server also supports validating token claims, ensuring the token matches expected values for specific keys, such as `role`, `permissions`, etc. This allows for more dynamic validation of Bearer tokens.

3. **Updated Configuration:**
   - The `config.yaml` file has been updated to support both **Basic Authentication** and **Bearer Token Authentication** for each endpoint.
   - Example configuration includes:
     - **Basic Auth** with `user` and `password` validation.
     - **Bearer Auth** with token and claims validation.